### PR TITLE
🐛 Search OCR on file sets only

### DIFF
--- a/app/models/iiif_print/iiif_search_decorator.rb
+++ b/app/models/iiif_print/iiif_search_decorator.rb
@@ -26,7 +26,7 @@ module IiifPrint
       return { q: 'nil:nil' } unless q
 
       {
-        q: "#{q} AND (#{iiif_config[:object_relation_field]}:\"#{parent_document.id}\" OR id:\"#{parent_document.id}\")",
+        q: "#{q} AND has_model_ssim:FileSet AND (#{iiif_config[:object_relation_field]}:\"#{parent_document.id}\" OR id:\"#{parent_document.id}\")",
         rows: rows,
         page: page
       }


### PR DESCRIPTION
This commit will constrain the IIIF search to only search the file sets of a work.  This way applications that use all_text_tsimv for both the file sets and work (to support snippets) will not have the work's text included in the search which would double the results.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/199

Before:
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/12cf4d43-9211-425d-8d3a-03bc4ba11840" />


After:
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/3b2218f4-967d-458f-ab42-331ff48a697b" />
