### PR TITLE
Fix pdf resplitting

### DIFF
--- a/app/controllers/iiif_print/split_pdfs_controller.rb
+++ b/app/controllers/iiif_print/split_pdfs_controller.rb
@@ -4,9 +4,10 @@ module IiifPrint
     before_action :authenticate_user!
 
     def create
-      @file_set = FileSet.where(id: params[:file_set_id]).first
+      @file_set = IiifPrint.find_by(id: params[:file_set_id])
       authorize_create_split_request!(@file_set)
-      IiifPrint::Jobs::RequestSplitPdfJob.perform_later(file_set: @file_set, user: current_user)
+
+      IiifPrint::Jobs::RequestSplitPdfJob.perform_later(file_set_id: @file_set.to_param, user: current_user)
       respond_to do |wants|
         wants.html { redirect_to polymorphic_path([main_app, @file_set]), notice: t("iiif_print.file_set.split_submitted", id: @file_set.id) }
         wants.json { render json: { id: @file_set.id, to_param: @file_set.to_param }, status: :ok }
@@ -27,7 +28,7 @@ module IiifPrint
       # Rely on CanCan's authorize! method.  We could add the :split_pdf action to the ability
       # class.  But we're pigging backing on the idea that you can do this if you can edit the work.
       authorize!(:edit, file_set)
-      raise "Expected #{file_set.class} ID=#{file_set.id} #to_param=#{file_set.to_param} to be a PDF.  Instead found mime_type of #{file_set.mime_type}." unless file_set.pdf?
+      raise "Expected #{file_set.class} ID=#{file_set.id} #to_param=#{file_set.to_param} to be a PDF.  Instead found mime_type of #{file_set.mime_type}." unless IiifPrint.pdf?(file_set)
 
       work = IiifPrint.parent_for(file_set)
       raise WorkNotConfiguredToSplitFileSetError.new(file_set: file_set, work: work) unless work&.iiif_print_config&.pdf_splitter_job&.presence

--- a/app/jobs/iiif_print/jobs/request_split_pdf_job.rb
+++ b/app/jobs/iiif_print/jobs/request_split_pdf_job.rb
@@ -4,12 +4,12 @@ module IiifPrint
     # Encapsulates logic for cleanup when the PDF is destroyed after pdf splitting into child works
     class RequestSplitPdfJob < IiifPrint::Jobs::ApplicationJob
       ##
-      # @param file_set [FileSet]
+      # @param file_set_id [FileSet id]
       # @param user [User]
       # rubocop:disable Metrics/MethodLength
-      def perform(file_set:, user:)
-        return true unless file_set.pdf?
-
+      def perform(file_set_id:, user:)
+        file_set = IiifPrint.find_by(id: file_set_id)
+        return true unless IiifPrint.pdf?(file_set)
         work = IiifPrint.parent_for(file_set)
 
         # Woe is ye who changes the configuration of the model, thus removing the splitting.
@@ -18,11 +18,11 @@ module IiifPrint
         # clean up any existing spawned child works of this file_set
         IiifPrint::SplitPdfs::DestroyPdfChildWorksService.conditionally_destroy_spawned_children_of(
           file_set: file_set,
-          work: work
+          work: work,
+          user: user
         )
 
-        location = Hyrax::WorkingDirectory.find_or_retrieve(file_set.files.first.id, file_set.id)
-
+        location = IiifPrint.pdf_path_for(file_set: file_set)
         IiifPrint.conditionally_submit_split_for(work: work, file_set: file_set, locations: [location], user: user)
       end
       # rubocop:enable Metrics/MethodLength

--- a/lib/iiif_print.rb
+++ b/lib/iiif_print.rb
@@ -66,6 +66,7 @@ module IiifPrint
       :solr_construct_query,
       :solr_name,
       :solr_query,
+      :pdf_path_for,
       to: :persistence_adapter
     )
   end

--- a/lib/iiif_print/persistence_layer.rb
+++ b/lib/iiif_print/persistence_layer.rb
@@ -113,6 +113,10 @@ module IiifPrint
       def self.extract_text_for(file_set:)
         raise NotImplementedError, "#{self}.{__method__}"
       end
+
+      def self.pdf_path_for(file_set:)
+        raise NotImplementedError, "#{self}.{__method__}"
+      end
     end
   end
 end

--- a/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
+++ b/lib/iiif_print/persistence_layer/active_fedora_adapter.rb
@@ -184,6 +184,15 @@ module IiifPrint
       def self.extract_text_for(file_set:)
         IiifPrint.config.all_text_generator_function.call(object: file_set) || ''
       end
+
+      ##
+      # Location of the file for resplitting
+      #
+      # @param [FileSet] an ActiveFedora fileset
+      # @return [String] location of the original file
+      def self.pdf_path_for(file_set:)
+        Hyrax::WorkingDirectory.find_or_retrieve(file_set.files.first.id, file_set.id)
+      end
     end
   end
 end


### PR DESCRIPTION
# Story

There were a few pieces of the pdf resplitting process that were not fully valkyrized. 

- This commit valkyrizes the resplitting, and fixes a bug with removing the child works from the initial split.
- Note that this also fixes the connection to delete the spawned child works when the parent work is deleted.

Ref https://github.com/notch8/palni_palci_knapsack/issues/80

# Expected Behavior Before Changes

PDF resplitting had numerous errors

# Expected Behavior After Changes

Using the PDF resplit button successfully removes prior child works and creates new ones
Deleting a work which has child works split from a PDF will also delete the child works.

# Screenshots / Video

<details>
<summary></summary>

Original work with "highlighted" child works:
![Screenshot 2025-01-29 at 5 19 47 PM](https://github.com/user-attachments/assets/6939ea3c-65f0-469d-a634-2b607367047f)

After resplit (highlighted works were deleted & replaced with new child work)
![Screenshot 2025-01-29 at 5 20 50 PM](https://github.com/user-attachments/assets/f183bec3-9fd1-4a1d-a43d-6a124c0800f2)

Original child work no longer found
![Screenshot 2025-01-29 at 5 21 05 PM](https://github.com/user-attachments/assets/69399802-4008-4aaf-80d7-3eae275d8136)

</details>

# Notes