### PR TITLE
Add rubocop disable for unused parameter

### DIFF
--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -86,7 +86,8 @@ module IiifPrint
       #  Building a custom query to find these child works directly via the attribute would be more efficient.
       #    However, it would require more effort for a lesser-used feature, and would not allow for the fallback
       #    of finding child works by title.
-      def self.destroy_children_split_from(file_set:, work:, _model:, user:)
+      # rubocop:disable Lint/UnusedMethodArgument
+      def self.destroy_children_split_from(file_set:, work:, model:, user:)
         all_child_works = Hyrax.custom_queries.find_child_works(resource: work)
         return if all_child_works.blank?
         # look first for children by the file set id they were split from
@@ -103,6 +104,7 @@ module IiifPrint
         end
         true
       end
+      # rubocop:enable Lint/UnusedMethodArgument
 
       def self.pdf?(file_set)
         file_set.original_file&.pdf?


### PR DESCRIPTION
The underscore was used to indicate that the parameter is not used in the method. This is a common pattern in Ruby and is used to indicate that the parameter is not needed for the method to function correctly.

However, this does not work with keyword arguments, so this change disables this rubocop test instead.
