### PR TITLE
Update version to v3.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /app/samvera/hyrax-webapp
   specs:
-    iiif_print (3.0.2)
+    iiif_print (3.0.3)
       blacklight_iiif_search (>= 1.0, < 3.0)
       derivative-rodeo (~> 0.5)
       hyrax (>= 2.5, < 6)
@@ -87,8 +87,8 @@ GEM
     awesome_nested_set (3.8.0)
       activerecord (>= 4.0.0, < 8.1)
     aws-eventstream (1.3.0)
-    aws-partitions (1.1043.0)
-    aws-sdk-core (3.217.0)
+    aws-partitions (1.1044.0)
+    aws-sdk-core (3.217.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)

--- a/lib/iiif_print/version.rb
+++ b/lib/iiif_print/version.rb
@@ -1,3 +1,3 @@
 module IiifPrint
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.3'.freeze
 end


### PR DESCRIPTION
Prepare for release of v3.0.3

This bump up version fixes an error caused by accommodating rubocop.