### PR TITLE
💄 fix rubocop offense

### DIFF
--- a/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
+++ b/lib/iiif_print/persistence_layer/valkyrie_adapter.rb
@@ -21,11 +21,11 @@ module IiifPrint
       # @param work_type [Class<Valkyrie::Resource>]
       # @return the indexer for the given :work_type
       def self.decorate_with_adapter_logic(work_type:)
-        work_type.send(:include, Hyrax::Schema(:child_works_from_pdf_splitting)) unless 
+        work_type.send(:include, Hyrax::Schema(:child_works_from_pdf_splitting)) unless
           Hyrax.config.try(:flexible?) || work_type.included_modules.include?(Hyrax::Schema(:child_works_from_pdf_splitting))
         # TODO: Use `Hyrax::ValkyrieIndexer.indexer_class_for` once changes are merged.
         indexer = "#{work_type}Indexer".constantize
-        indexer.send(:include, Hyrax::Indexer(:child_works_from_pdf_splitting)) unless 
+        indexer.send(:include, Hyrax::Indexer(:child_works_from_pdf_splitting)) unless
           Hyrax.config.try(:flexible?) || indexer.included_modules.include?(Hyrax::Indexer(:child_works_from_pdf_splitting))
         indexer
       end
@@ -35,7 +35,7 @@ module IiifPrint
       # @return form for the given :work_type
       def self.decorate_form_with_adapter_logic(work_type:)
         form = "#{work_type}Form".constantize
-        form.send(:include, Hyrax::FormFields(:child_works_from_pdf_splitting)) unless 
+        form.send(:include, Hyrax::FormFields(:child_works_from_pdf_splitting)) unless
           Hyrax.config.try(:flexible?) || form.included_modules.include?(Hyrax::FormFields(:child_works_from_pdf_splitting))
         form
       end


### PR DESCRIPTION
I accidentally merged in a lint offense. This PR corrects it: 

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/a4fdeba8-b564-4414-a522-3b6a2b0552cd" />
