### PR TITLE
🐛 Return FileSet resource in transaction

### DIFF
--- a/app/transactions/hyrax/transactions/steps/conditionally_destroy_children_from_split.rb
+++ b/app/transactions/hyrax/transactions/steps/conditionally_destroy_children_from_split.rb
@@ -14,7 +14,7 @@ module Hyrax
           return Failure(:resource_not_persisted) unless resource.persisted?
 
           parent = IiifPrint.persistence_adapter.parent_for(resource)
-          return Success(true) unless parent
+          return Success(resource) unless parent
 
           # We do not care about the results of this call; as it is conditionally looking for things
           # to destroy.

--- a/spec/transactions/hyrax/transactions/steps/conditionally_destroy_children_from_split_spec.rb
+++ b/spec/transactions/hyrax/transactions/steps/conditionally_destroy_children_from_split_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe Hyrax::Transactions::Steps::ConditionallyDestroyChildrenFromSplit
       context 'without a parent' do
         let(:parent) { nil }
         it { is_expected.to be_success }
+
+        it 'returns the file_set resource' do
+          expect(subject.value!).to eq(file_set)
+        end
       end
 
       context 'with a parent' do
@@ -27,6 +31,12 @@ RSpec.describe Hyrax::Transactions::Steps::ConditionallyDestroyChildrenFromSplit
           expect(IiifPrint::SplitPdfs::DestroyPdfChildWorksService).to receive(:conditionally_destroy_spawned_children_of)
             .with(file_set: file_set, work: parent, user: nil)
           is_expected.to be_success
+        end
+
+        it 'returns the file_set resource' do
+          expect(IiifPrint::SplitPdfs::DestroyPdfChildWorksService).to receive(:conditionally_destroy_spawned_children_of)
+            .with(file_set: file_set, work: parent, user: nil)
+          expect(subject.value!).to eq(file_set)
         end
       end
     end


### PR DESCRIPTION
# Story

Regardless of the status of the parent, always return the FileSet resource instead of boolean true when no parent is found in ConditionallyDestroyChildrenFromSplit. This will ensure consistent return values across all code paths in the transaction step.

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/477

# Expected Behavior Before Changes

Deleting a work in Hyku that has a file set that was migrated from Active Fedora into Postgres produced an error.

# Expected Behavior After Changes

All works can be deleted regardless of Active Fedora, Postgres, or file set status.

# Screenshots / Video

<details>
<summary>Before: Error on deletion</summary>

<img width="1217" height="789" alt="480696993-518fb8ed-9195-4903-be6a-a91d616e5279" src="https://github.com/user-attachments/assets/bd875514-8b94-4aee-ab52-4d3414a86f8f" />

</details>

<details>
<summary>After: Migrating and deleting a work with a file set</summary>

https://github.com/user-attachments/assets/7056f1c9-4fc5-452f-862d-ac08cfd94965

</details>